### PR TITLE
Remove peach-melpa link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ Download `tron-legacy-theme.el` and put it under `~/.emacs.d/themes/` (or `~/.co
 
 <br>
 
-### More in-action moments of `tron-legacy`
-
-Tron-legacy theme [showcase](https://peach-melpa.org/themes/tron-legacy-theme?lang=js&variant=tron-legacy) on Peach Melpa.
-
 ### Main color palette:
 
 


### PR DESCRIPTION
It's taken over by some spam site now.

Archive.org says it went down sometime between 2022-05 and 2023-09. Rest in peace.